### PR TITLE
데이터 없을 경우 Mono 오류 분리하도록 수정, 디렉토리 모델이동 시, 결과 나오지 않는 버그 수정

### DIFF
--- a/src/main/kotlin/me/jhan/file/toy/service/DirectoryService.kt
+++ b/src/main/kotlin/me/jhan/file/toy/service/DirectoryService.kt
@@ -153,7 +153,7 @@ class DirectoryService(
             }
             .flatMap { // 과거 디렉토리 모델 삭제
                 val next = it;
-                directoryRepository.delete(it.first).map { next.second }
+                directoryRepository.delete(it.first).thenReturn(next.second)
             }
     }
 

--- a/src/main/kotlin/me/jhan/file/toy/util/ErrorMonoUtil.kt
+++ b/src/main/kotlin/me/jhan/file/toy/util/ErrorMonoUtil.kt
@@ -1,0 +1,12 @@
+package me.jhan.file.toy.util
+
+import reactor.core.publisher.Mono
+
+fun <T> notExistsMono(objectName: String) : Mono<T> = Mono.error {
+    IllegalArgumentException("${objectName}이(가) 존재하지 않습니다.")
+}
+
+fun <T> brokenStableDBMono(objectName: String, objectKey: Any) : Mono<T> = Mono.error {
+    IllegalStateException("${objectName} 모델의 DB 오류가 있습니다.. key: ${objectKey}")
+}
+


### PR DESCRIPTION
- 데이터가 없을 경우 자동으로 빈 데이터를 반환하여 200이 떨어지도록 되어있음 > 명시적으로 검사하여 오류를 반환하도록 변경
- 디렉토리 이동시, 결과 값을 반환하도록 수정